### PR TITLE
feat: add avoid_using_datetime_now lint

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -108,6 +108,7 @@ custom_lint:
         - "test/**/*.dart"
         - "integration_test/*.dart"
         - "integration_test/**/*.dart"
+    - avoid_using_datetime_now:
     - avoid_using_if_else_with_enums:
       include_conditional_expression: false
       excludes:

--- a/lib/exception/remote_exception.dart
+++ b/lib/exception/remote_exception.dart
@@ -18,7 +18,7 @@ class RemoteException extends AppException {
 
   String get _apiInfo => Env.flavor == Flavor.production || Env.flavor == Flavor.test
       ? ''
-      : '\nTime: ${DateTime.now().toStringWithFormat(Constant.fddMMyyyyHHmm)}\nPath: $apiInfo';
+      : '\nTime: ${DateTimeUtil.now.toStringWithFormat(Constant.fddMMyyyyHHmm)}\nPath: $apiInfo';
 
   @override
   String get message =>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -70,7 +70,7 @@ dependencies:
 dev_dependencies:
   auto_route_generator: 10.2.3
   build_runner: 2.4.15
-  custom_lint: 0.7.5
+  custom_lint: 0.8.0
   # dart_code_metrics: 5.7.6
   flutter_driver:
     sdk: flutter

--- a/super_lint/doc/LINTS.md
+++ b/super_lint/doc/LINTS.md
@@ -37,6 +37,7 @@
   - [missing_expanded_or_flexible](#missing_expanded_or_flexible)
   - [incorrect_parent_class](#incorrect_parent_class)
   - [avoid_hard_coded_strings](#avoid_hard_coded_strings)
+  - [avoid_using_datetime_now](#avoid_using_datetime_now)
 
 ## All lint rules
 
@@ -975,4 +976,24 @@ Text(AppStrings.welcomeMessage)
 
 ```dart
 Text('Welcome to the app!')
+```
+
+### avoid_using_datetime_now
+
+Use `now` instead of `DateTime.now()`.
+
+```yaml
+- avoid_using_datetime_now:
+```
+
+**Good**:
+
+```dart
+final current = now;
+```
+
+**Bad**:
+
+```dart
+final current = DateTime.now();
 ```

--- a/super_lint/example/analysis_options.yaml
+++ b/super_lint/example/analysis_options.yaml
@@ -59,6 +59,7 @@ custom_lint:
     - incorrect_event_parameter_name:
     - incorrect_event_parameter_type:
     - incorrect_event_name:
+    - avoid_using_datetime_now:
     - avoid_using_unsafe_cast:
     - prefer_single_widget_per_file:
     - incorrect_freezed_default_value_type:

--- a/super_lint/example/lib/avoid_using_datetime_now_test/avoid_using_datetime_now_test.dart
+++ b/super_lint/example/lib/avoid_using_datetime_now_test/avoid_using_datetime_now_test.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: avoid_dynamic, avoid_hard_coded_strings
+// ignore_for_file: avoid_dynamic, avoid_hard_coded_strings, unused_local_variable
 // ~.~.~.~.~.~.~.~ THE FOLLOWING CASES SHOULD NOT BE WARNED ~.~.~.~.~.~.~.~
 
 DateTime get now => DateTime(0);
@@ -13,4 +13,3 @@ void test() {
   final current = DateTime.now();
   print(current);
 }
-

--- a/super_lint/example/lib/avoid_using_datetime_now_test/avoid_using_datetime_now_test.dart
+++ b/super_lint/example/lib/avoid_using_datetime_now_test/avoid_using_datetime_now_test.dart
@@ -1,0 +1,16 @@
+// ignore_for_file: avoid_dynamic, avoid_hard_coded_strings
+// ~.~.~.~.~.~.~.~ THE FOLLOWING CASES SHOULD NOT BE WARNED ~.~.~.~.~.~.~.~
+
+DateTime get now => DateTime(0);
+
+void main() {
+  final current = now;
+}
+
+// ~.~.~.~.~.~.~.~ THE FOLLOWING CASES SHOULD BE WARNED ~.~.~.~.~.~.~.~
+void test() {
+  // expect_lint: avoid_using_datetime_now
+  final current = DateTime.now();
+  print(current);
+}
+

--- a/super_lint/example/lib/incorrect_event_parameter_type_test/incorrect_event_parameter_type_test.dart
+++ b/super_lint/example/lib/incorrect_event_parameter_type_test/incorrect_event_parameter_type_test.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: prefer_single_widget_per_file, avoid_hard_coded_strings
+// ignore_for_file: prefer_single_widget_per_file, avoid_hard_coded_strings, avoid_using_datetime_now
 abstract class AnalyticParameter {
   Map<String, Object>? get parameters;
 }

--- a/super_lint/example/pubspec.yaml
+++ b/super_lint/example/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  custom_lint: 0.7.5
+  custom_lint: 0.8.0
   super_lint:
     path: ../
 flutter:

--- a/super_lint/lib/src/index.dart
+++ b/super_lint/lib/src/index.dart
@@ -35,6 +35,7 @@ export 'lints/avoid_hard_coded_colors.dart';
 export 'lints/avoid_hard_coded_strings.dart';
 export 'lints/avoid_nested_conditions.dart';
 export 'lints/avoid_unnecessary_async_function.dart';
+export 'lints/avoid_using_datetime_now.dart';
 export 'lints/avoid_using_if_else_with_enums.dart';
 export 'lints/avoid_using_text_style_constructor_directly.dart';
 export 'lints/avoid_using_unsafe_cast.dart';

--- a/super_lint/lib/src/lints/avoid_using_datetime_now.dart
+++ b/super_lint/lib/src/lints/avoid_using_datetime_now.dart
@@ -22,8 +22,7 @@ class AvoidUsingDateTimeNow extends CommonLintRule<_AvoidUsingDateTimeNowParamet
     context.registry.addInstanceCreationExpression((node) {
       final type = node.constructorName.type.type;
       final name = node.constructorName.name?.name;
-      if (type?.getDisplayString(withNullability: false) == 'DateTime' &&
-          name == 'now') {
+      if (type?.getDisplayString() == 'DateTime' && name == 'now') {
         reporter.atNode(node, code);
       }
     });
@@ -35,8 +34,7 @@ class AvoidUsingDateTimeNow extends CommonLintRule<_AvoidUsingDateTimeNowParamet
       ];
 }
 
-class _AvoidUsingDateTimeNowFix
-    extends CommonQuickFix<_AvoidUsingDateTimeNowParameter> {
+class _AvoidUsingDateTimeNowFix extends CommonQuickFix<_AvoidUsingDateTimeNowParameter> {
   _AvoidUsingDateTimeNowFix(super.config);
 
   @override
@@ -54,14 +52,13 @@ class _AvoidUsingDateTimeNowFix
       }
       final type = node.constructorName.type.type;
       final name = node.constructorName.name?.name;
-      if (type?.getDisplayString(withNullability: false) == 'DateTime' &&
-          name == 'now') {
+      if (type?.getDisplayString() == 'DateTime' && name == 'now') {
         final changeBuilder = reporter.createChangeBuilder(
-          message: "Replace with 'now'",
+          message: "Replace with 'DateTimeUtil.now'",
           priority: 70,
         );
         changeBuilder.addDartFileEdit((builder) {
-          builder.addSimpleReplacement(sourceRange, 'now');
+          builder.addSimpleReplacement(sourceRange, 'DateTimeUtil.now');
         });
       }
     });
@@ -83,4 +80,3 @@ class _AvoidUsingDateTimeNowParameter extends CommonLintParameter {
     );
   }
 }
-

--- a/super_lint/lib/src/lints/avoid_using_datetime_now.dart
+++ b/super_lint/lib/src/lints/avoid_using_datetime_now.dart
@@ -1,0 +1,86 @@
+import '../index.dart';
+
+class AvoidUsingDateTimeNow extends CommonLintRule<_AvoidUsingDateTimeNowParameter> {
+  AvoidUsingDateTimeNow(
+    CustomLintConfigs configs,
+  ) : super(
+          RuleConfig(
+            name: 'avoid_using_datetime_now',
+            configs: configs,
+            paramsParser: _AvoidUsingDateTimeNowParameter.fromMap,
+            problemMessage: (_) => "Avoid using DateTime.now(), use 'now' instead.",
+          ),
+        );
+
+  @override
+  Future<void> check(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+    String rootPath,
+  ) async {
+    context.registry.addInstanceCreationExpression((node) {
+      final type = node.constructorName.type.type;
+      final name = node.constructorName.name?.name;
+      if (type?.getDisplayString(withNullability: false) == 'DateTime' &&
+          name == 'now') {
+        reporter.atNode(node, code);
+      }
+    });
+  }
+
+  @override
+  List<Fix> getFixes() => [
+        _AvoidUsingDateTimeNowFix(config),
+      ];
+}
+
+class _AvoidUsingDateTimeNowFix
+    extends CommonQuickFix<_AvoidUsingDateTimeNowParameter> {
+  _AvoidUsingDateTimeNowFix(super.config);
+
+  @override
+  Future<void> run(
+    CustomLintResolver resolver,
+    ChangeReporter reporter,
+    CustomLintContext context,
+    AnalysisError analysisError,
+    List<AnalysisError> others,
+  ) async {
+    context.registry.addInstanceCreationExpression((node) {
+      final sourceRange = node.sourceRange;
+      if (!sourceRange.intersects(analysisError.sourceRange)) {
+        return;
+      }
+      final type = node.constructorName.type.type;
+      final name = node.constructorName.name?.name;
+      if (type?.getDisplayString(withNullability: false) == 'DateTime' &&
+          name == 'now') {
+        final changeBuilder = reporter.createChangeBuilder(
+          message: "Replace with 'now'",
+          priority: 70,
+        );
+        changeBuilder.addDartFileEdit((builder) {
+          builder.addSimpleReplacement(sourceRange, 'now');
+        });
+      }
+    });
+  }
+}
+
+class _AvoidUsingDateTimeNowParameter extends CommonLintParameter {
+  const _AvoidUsingDateTimeNowParameter({
+    super.excludes,
+    super.includes,
+    super.severity,
+  });
+
+  static _AvoidUsingDateTimeNowParameter fromMap(Map<String, dynamic> map) {
+    return _AvoidUsingDateTimeNowParameter(
+      excludes: safeCastToListString(map['excludes']),
+      includes: safeCastToListString(map['includes']),
+      severity: convertStringToErrorSeverity(map['severity']),
+    );
+  }
+}
+

--- a/super_lint/lib/super_lint.dart
+++ b/super_lint/lib/super_lint.dart
@@ -39,6 +39,7 @@ class _SuperLintPlugin extends PluginBase {
       PreferSingleWidgetPerFile(configs),
       RequireMatchingFileAndClassName(configs),
       MissingGoldenTest(configs),
+      AvoidUsingDateTimeNow(configs),
     ];
   }
 }

--- a/super_lint/pubspec.yaml
+++ b/super_lint/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   change_case: 2.2.0
   collection: 1.19.1
-  custom_lint_builder: 0.7.5
+  custom_lint_builder: 0.8.0
   flutter_lints: 6.0.0
   glob: 2.1.3
   path: 1.9.1


### PR DESCRIPTION
## Summary
- add custom lint to forbid using `DateTime.now()`
- provide quick fix to replace `DateTime.now()` with `now`
- document and enable the new lint

## Testing
- `bash .lefthook/pre-commit/pre-commit.sh` *(fails: feat/58 is bad branch name)*

------
https://chatgpt.com/codex/tasks/task_e_68a804477a50832ead48a878fad4c02f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced lint rule “avoid_using_datetime_now” to flag uses of DateTime.now() and suggest using now instead.
  - Includes an automatic quick-fix to replace DateTime.now() with now.
  - Enabled by default in project and example configurations.

- Documentation
  - Added rule documentation with configuration guidance and good/bad usage examples.

- Tests
  - Added example tests demonstrating cases that trigger and don’t trigger the rule.

- Chores
  - Updated analysis options to include the new rule across the project and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->