### PR TITLE
62: upgrade to Android api 36

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 android {
     namespace = "jp.flutter.app"
-    compileSdk = 35
+    compileSdk = 36
     ndkVersion = flutter.ndkVersion
 
     compileOptions {
@@ -25,7 +25,7 @@ android {
     defaultConfig {
         applicationId = "jp.flutter.app"
         minSdk = 26
-        targetSdk = 35
+        targetSdk = 36
         versionCode = flutter.versionCode
         versionName = flutter.versionName
         multiDexEnabled true

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -13,7 +13,6 @@
         android:allowBackup="false"
         tools:replace="android:allowBackup">
         <activity
-            android:screenOrientation="portrait"
             android:exported="true"
             android:name=".MainActivity"
             android:launchMode="singleInstance"

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.3.2" apply false
-    id "org.jetbrains.kotlin.android" version "2.0.20" apply false
+    id "com.android.application" version '8.9.1' apply false
+    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
     id "com.google.gms.google-services" version "4.4.0" apply false
     id "com.google.firebase.crashlytics" version "2.9.9" apply false
 }

--- a/lib/app_initializer.dart
+++ b/lib/app_initializer.dart
@@ -14,6 +14,7 @@ class AppInitializer {
           ? Constant.mobileOrientation
           : Constant.tabletOrientation,
     );
-    SystemChrome.setSystemUIOverlayStyle(Constant.systemUiOverlay);
+    // Edge to Edge
+    await SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
   }
 }

--- a/lib/data_source/database/app_database.dart
+++ b/lib/data_source/database/app_database.dart
@@ -1,6 +1,6 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:injectable/injectable.dart';
-import 'package:isar/isar.dart';
+import 'package:isar_community/isar.dart';
 import 'package:path_provider/path_provider.dart';
 
 import '../../index.dart';

--- a/lib/di.dart
+++ b/lib/di.dart
@@ -1,6 +1,6 @@
 import 'package:get_it/get_it.dart';
 import 'package:injectable/injectable.dart';
-import 'package:isar/isar.dart';
+import 'package:isar_community/isar.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 // ignore: prefer_importing_index_file

--- a/lib/model/database/local_message_data.dart
+++ b/lib/model/database/local_message_data.dart
@@ -1,5 +1,5 @@
 import 'package:chatview/chatview.dart' as cv;
-import 'package:isar/isar.dart';
+import 'package:isar_community/isar.dart';
 
 import '../../index.dart';
 

--- a/lib/model/database/local_reply_message_data.dart
+++ b/lib/model/database/local_reply_message_data.dart
@@ -1,5 +1,5 @@
 import 'package:chatview/chatview.dart' as cv;
-import 'package:isar/isar.dart';
+import 'package:isar_community/isar.dart';
 
 import '../../index.dart';
 

--- a/lib/ui/page/home/home_page.dart
+++ b/lib/ui/page/home/home_page.dart
@@ -50,6 +50,7 @@ class HomePage extends BasePage<HomeState,
       shimmerEnabled: true,
       appBar: CommonAppBar.back(text: l10n.home),
       body: SafeArea(
+        bottom: false,
         child: Stack(
           fit: StackFit.expand,
           children: [

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,12 +55,10 @@ dependencies:
   infinite_scroll_pagination: 5.0.0
   injectable: 2.5.0
   intl: 0.20.2
-  isar:
-    version: 3.1.8
-    hosted: https://pub.isar-community.dev/
-  isar_flutter_libs: # contains Isar Core
-    version: 3.1.8
-    hosted: https://pub.isar-community.dev/
+  isar_community: 
+    version: ^3.3.0-dev.1
+  isar_community_flutter_libs: # contains Isar Core
+    version: ^3.3.0-dev.1
   json_annotation: 4.9.0
   mime: 2.0.0
   package_info_plus: 8.3.0
@@ -85,11 +83,8 @@ dev_dependencies:
   integration_test:
     sdk: flutter
   intl_utils: 2.8.10
-  isar_generator:
-    git:
-      url: https://github.com/minhnt3/isar
-      ref: v3
-      path: packages/isar_generator/
+  isar_community_generator: 
+    version: ^3.3.0-dev.1
   json_serializable: 6.9.5
   mocktail: 1.0.4
   mocktail_image_network: 1.2.0

--- a/test/unit_test/data_source/database/app_database_test.dart
+++ b/test/unit_test/data_source/database/app_database_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:isar/isar.dart';
+import 'package:isar_community/isar.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nalsflutter/index.dart';
 


### PR DESCRIPTION
## Issue

- Migrate to Android SDK 36
- Support 16KB page size
- Support Edge to Edge

## Impact on existing code
- Flutter SDK 3.35.1
- Android SDK 36
- AGP 8.9.1
- Gradle 8.11.1
- Kotlin 2.1.0
- JVM 17

## Screenshots (only UI that do not have golden images)

| State    	| Screenshot                 	| Note 	|
|----------	|----------------------------	|------	|
| Android 15+  	|  <img alt="Screenshot_1758243924" src="https://github.com/user-attachments/assets/d2ecfddf-a326-426a-8966-9d6f52e63411"  width="150" />	|      	|
| Android < 15  	|  <img width="150" alt="Screenshot_1758242713" src="https://github.com/user-attachments/assets/bafdcb53-b367-4dc3-b24f-782b0906a155" />	|      	|

## Note


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enabled landscape support; app no longer locked to portrait.
  - Edge-to-edge UI with content extending to the bottom for a more immersive layout.
- Improvements
  - Updated Android target and compile SDK to 36 for improved compatibility with the latest Android versions.
  - More reliable system UI initialization during app start.
- Chores
  - Upgraded build tooling (Gradle, Android plugin, Kotlin).
  - Migrated database dependencies to community-maintained packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->